### PR TITLE
Add warmup_steps_ratio support

### DIFF
--- a/pretrain.py
+++ b/pretrain.py
@@ -1,6 +1,8 @@
 """
 Main script for pre-training the baseline SSM model (Phase A).
 This script implements the M_base training and will be extended for M_SDM with structured masking.
+The configuration can optionally define ``warmup_steps_ratio`` to calculate warmup
+steps from ``max_steps``.
 """
 
 import argparse
@@ -141,12 +143,17 @@ def main():
         warmup_steps = int(pretrain_config.get('warmup_steps', 1000))
         max_grad_norm = float(pretrain_config.get('max_grad_norm', 1.0))
         max_steps = int(pretrain_config.get('max_epochs', 20)) * 1000  # Convert epochs to steps estimate
+        warmup_steps_ratio = pretrain_config.get('warmup_steps_ratio')
     else:
         learning_rate = float(training_config.get('learning_rate', 1e-4))
         weight_decay = float(training_config.get('weight_decay', 0.1))
         warmup_steps = int(training_config.get('warmup_steps', 1000))
         max_grad_norm = float(training_config.get('max_grad_norm', 1.0))
         max_steps = int(training_config.get('max_steps', 20000))
+        warmup_steps_ratio = training_config.get('warmup_steps_ratio')
+
+    if warmup_steps_ratio is not None:
+        warmup_steps = int(max_steps * float(warmup_steps_ratio))
     
     # Get data configuration with memory optimization
     data_config = config.get('data', {})

--- a/pretrain_sdm.py
+++ b/pretrain_sdm.py
@@ -3,6 +3,8 @@ SDM Pre-training Script - Pillar 2: Structured Differentiable Masking
 
 This script implements the pre-training of M_SDM with integrated sparsity learning.
 The model learns both task performance and channel importance simultaneously.
+If ``warmup_steps_ratio`` is provided in the configuration, warmup steps are
+calculated as ``int(max_steps * warmup_steps_ratio)``.
 """
 
 import argparse
@@ -290,12 +292,17 @@ def main():
         warmup_steps = int(pretrain_config.get('warmup_steps', 1000))
         max_grad_norm = float(pretrain_config.get('max_grad_norm', 1.0))
         max_steps = int(pretrain_config.get('max_epochs', 20)) * 1000  # Convert epochs to steps estimate
+        warmup_steps_ratio = pretrain_config.get('warmup_steps_ratio')
     else:
         learning_rate = float(training_config.get('learning_rate', 1e-4))
         weight_decay = float(training_config.get('weight_decay', 0.1))
         warmup_steps = int(training_config.get('warmup_steps', 1000))
         max_grad_norm = float(training_config.get('max_grad_norm', 1.0))
         max_steps = int(training_config.get('max_steps', 20000))
+        warmup_steps_ratio = training_config.get('warmup_steps_ratio')
+
+    if warmup_steps_ratio is not None:
+        warmup_steps = int(max_steps * float(warmup_steps_ratio))
     
     # Get data configuration
     data_config = config.get('data', {})

--- a/scripts/run_finetuning.py
+++ b/scripts/run_finetuning.py
@@ -6,6 +6,7 @@ This script implements the complete fine-tuning pipeline using SGH-PEFT:
 2. Compute layer-wise importance scores from z_logits
 3. Apply hybrid LoRA/IA³ adapters based on importance
 4. Fine-tune on downstream tasks (GLUE)
+The scheduler supports ``warmup_steps_ratio`` to derive warmup steps from ``max_steps``.
 """
 
 import argparse
@@ -386,9 +387,14 @@ def main():
     )
     
     num_training_steps = config['training']['max_steps']
+    warmup_steps = int(config['training'].get('warmup_steps', 0))
+    warmup_steps_ratio = config['training'].get('warmup_steps_ratio')
+    if warmup_steps_ratio is not None:
+        warmup_steps = int(num_training_steps * float(warmup_steps_ratio))
+
     scheduler = get_linear_schedule_with_warmup(
         optimizer,
-        num_warmup_steps=config['training']['warmup_steps'],
+        num_warmup_steps=warmup_steps,
         num_training_steps=num_training_steps
     )
     


### PR DESCRIPTION
## Summary
- support `warmup_steps_ratio` in pretraining and finetuning scripts
- compute warmup steps from ratio when provided
- document the new behaviour in each script

## Testing
- `python tests/run_all_tests.py`
- `python -m pytest tests/test_pretrain_sdm.py -v`

------
https://chatgpt.com/codex/tasks/task_e_684e77a7b3208333b76ff3d2283bf5d1