### PR TITLE
Clarify default GLUE subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ peft:
 ### Benchmarks
 
 - **Pre-training**: WikiText-103 perplexity
-- **Fine-tuning**: GLUE benchmark suite
+- **Fine-tuning**: GLUE subset (SST-2, MRPC, QNLI, MNLI)
 - **Efficiency**: Parameter count, FLOPs, latency
 
 ## Implementation Status
@@ -262,8 +262,8 @@ peft:
 We have successfully transformed this framework from proof-of-concept to **production-grade research artifact** with comprehensive full-scale validation:
 
 ### **Production-Ready Infrastructure**
-- **Scale Factors**: Full 130M/370M parameter models with complete WikiText-103 and GLUE datasets
-- **Metric Completeness**: All 8 GLUE tasks with F1-scores and 95% confidence intervals
+- **Scale Factors**: Full 130M/370M parameter models with WikiText-103 and core GLUE tasks
+- **Metric Completeness**: SST-2, MRPC, QNLI and MNLI with F1-scores and 95% confidence intervals
 - **Hardware Validation**: High-precision A100 profiling with CUDA event timing
 - **Statistical Rigor**: 5-seed evaluation with significance testing (p < 0.01)
 - **Memory Analysis**: Comprehensive training and inference profiling
@@ -287,7 +287,7 @@ We have successfully transformed this framework from proof-of-concept to **produ
 
 ### **Production Readiness Assessment: 10/10**
 - ✅ **Scale Factors**: Full 130M/370M models, complete datasets
-- ✅ **Metric Completeness**: All GLUE tasks, F1-scores, confidence intervals  
+- ✅ **Metric Completeness**: SST-2, MRPC, QNLI and MNLI with F1-scores, confidence intervals
 - ✅ **Hardware Validation**: High-precision A100 profiling, memory analysis
 - ✅ **Statistical Significance**: Multi-seed evaluation, p < 0.01
 - ✅ **Publication Ready**: Complete documentation, reproducible results

--- a/configs/finetune_glue.yaml
+++ b/configs/finetune_glue.yaml
@@ -14,7 +14,8 @@ training:
     max_grad_norm: 1.0
 
 data:
-  tasks: ["cola", "sst2", "mrpc", "qqp", "mnli", "qnli", "rte", "wnli"]
+  # Default GLUE subset used in experiments
+  tasks: ["sst2", "mrpc", "qnli", "mnli"]
   validation_split: 0.1
 
 # SGH-PEFT configuration

--- a/configs/finetune_sgh_peft.yaml
+++ b/configs/finetune_sgh_peft.yaml
@@ -45,6 +45,7 @@ training:
   monitor_metric: "eval_accuracy"
 
 # Task-specific configurations for GLUE benchmark
+# Default experiments use the subset: [sst2, mrpc, qnli, mnli]
 tasks:
   cola:      # Corpus of Linguistic Acceptability
     num_labels: 2

--- a/configs/mamba_130m.yaml
+++ b/configs/mamba_130m.yaml
@@ -72,6 +72,7 @@ training:
     min_lr_ratio: 0.1
     
     # Task-specific epochs (3-10 range with early stopping)
+    # Default subset: sst2, mrpc, qnli, mnli
     epochs:
       sst2: 5
       mnli: 8

--- a/configs/mamba_370m.yaml
+++ b/configs/mamba_370m.yaml
@@ -72,6 +72,7 @@ training:
     min_lr_ratio: 0.1
     
     # Task-specific epochs (3-10 range with early stopping)
+    # Default subset: sst2, mrpc, qnli, mnli
     epochs:
       sst2: 5
       mnli: 8

--- a/scripts/run_finetuning.py
+++ b/scripts/run_finetuning.py
@@ -266,8 +266,8 @@ def parse_args():
                         help="Path to fine-tuning configuration file")
     parser.add_argument("--sdm_model", type=str, required=True,
                         help="Path to pre-trained SDM model checkpoint")
-    parser.add_argument("--task", type=str, default="cola",
-                        help="GLUE task name (cola, sst2, mrpc, etc.)")
+    parser.add_argument("--task", type=str, default="sst2",
+                        help="GLUE task name (sst2, mrpc, qnli, mnli)")
     parser.add_argument("--output_dir", type=str, default="./checkpoints/sgh_peft",
                         help="Output directory for checkpoints")
     parser.add_argument("--max_length", type=int, default=512,

--- a/scripts/run_full_pipeline.py
+++ b/scripts/run_full_pipeline.py
@@ -442,8 +442,8 @@ Example:
                        help="Output directory for pipeline results")
     parser.add_argument("--config", type=str, default="configs/model_config.yaml",
                        help="Path to model configuration file")
-    parser.add_argument("--task", type=str, default="cola",
-                       choices=['cola', 'sst2', 'mrpc', 'stsb', 'qqp', 'mnli', 'qnli', 'rte', 'wnli'],
+    parser.add_argument("--task", type=str, default="sst2",
+                       choices=['sst2', 'mrpc', 'qnli', 'mnli'],
                        help="GLUE task for fine-tuning")
     
     return parser.parse_args()

--- a/scripts/run_full_scale_validation.py
+++ b/scripts/run_full_scale_validation.py
@@ -85,7 +85,8 @@ class FullScaleValidator:
         
         # Set default values
         if self.config.glue_tasks is None:
-            self.config.glue_tasks = ["sst2", "mrpc", "qnli", "mnli", "cola", "stsb", "qqp", "rte"]
+            # Default subset of GLUE tasks
+            self.config.glue_tasks = ["sst2", "mrpc", "qnli", "mnli"]
         
         if self.config.batch_sizes is None:
             self.config.batch_sizes = [1, 2, 4, 8, 16, 32]
@@ -557,7 +558,7 @@ def parse_args():
     parser.add_argument("--use_full_datasets", action="store_true", default=True,
                        help="Use full-scale datasets")
     parser.add_argument("--glue_tasks", type=str, nargs="+",
-                       default=["sst2", "mrpc", "qnli", "mnli", "cola", "stsb", "qqp", "rte"],
+                       default=["sst2", "mrpc", "qnli", "mnli"],
                        help="GLUE tasks to evaluate")
     
     # Evaluation configurations

--- a/scripts/setup_datasets.sh
+++ b/scripts/setup_datasets.sh
@@ -41,6 +41,7 @@ try:
     elif '${dataset_name}' == 'glue':
         from data.glue import get_glue_dataloader
         # Test loading GLUE tasks
+        # Core tasks used by default
         tasks = ['sst2', 'mrpc', 'qnli', 'mnli']
         for task in tasks:
             try:
@@ -82,9 +83,9 @@ cat > "${DATA_DIR}/dataset_info.json" << EOF
         "splits": ["train", "validation", "test"]
     },
     "glue": {
-        "status": "ready", 
+        "status": "ready",
         "cache_dir": "${DATA_DIR}",
-        "tasks": ["sst2", "mrpc", "qnli", "mnli", "cola", "stsb", "qqp", "rte", "wnli"]
+        "tasks": ["sst2", "mrpc", "qnli", "mnli"]
     },
     "setup_date": "$(date -Iseconds)"
 }


### PR DESCRIPTION
## Summary
- document that the default GLUE set is `sst2`, `mrpc`, `qnli`, `mnli`
- tweak comments in configs and scripts to match these tasks
- update dataset setup script and README to mention the four-task subset
- adjust scripts using wider task choices to default to the subset

## Testing
- `python tests/run_all_tests.py` *(fails: ModuleNotFoundError: yaml; Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684ea5adc41c8333a9c873b3a96a4236