### PR TITLE
Fix wikitext dataloader name

### DIFF
--- a/data/wikitext103.py
+++ b/data/wikitext103.py
@@ -192,7 +192,7 @@ class WikiText103Dataset(Dataset):
         }
 
 
-def get_wiktext103_dataloader(
+def get_wikitext103_dataloader(
     split: str = "train",
     batch_size: int = 8,
     max_length: int = 1024,
@@ -344,7 +344,7 @@ def verify_dataset_loading():
     
     try:
         # Test small batch
-        dataloader = get_wiktext103_dataloader(
+        dataloader = get_wikitext103_dataloader(
             split="validation",
             batch_size=2,
             max_length=512,

--- a/pretrain.py
+++ b/pretrain.py
@@ -15,7 +15,7 @@ from transformers import AutoTokenizer, get_linear_schedule_with_warmup
 from accelerate import Accelerator
 
 from models.baseline_ssm import BaselineSSM
-from data.wikitext103 import get_wiktext103_dataloader
+from data.wikitext103 import get_wikitext103_dataloader
 from utils.logger import setup_logger, setup_wandb, log_model_info, log_training_info
 from utils.profiling import count_parameters, count_flops
 
@@ -182,7 +182,7 @@ def main():
         except Exception as e:
             logger.warning(f"FLOPs counting failed: {e}")
     
-    train_dataloader = get_wiktext103_dataloader(
+    train_dataloader = get_wikitext103_dataloader(
         tokenizer_name="gpt2",
         batch_size=micro_batch_size,
         max_length=max_length,
@@ -190,7 +190,7 @@ def main():
         num_workers=num_workers
     )
     
-    val_dataloader = get_wiktext103_dataloader(
+    val_dataloader = get_wikitext103_dataloader(
         tokenizer_name="gpt2",
         batch_size=micro_batch_size,
         max_length=max_length,

--- a/pretrain_sdm.py
+++ b/pretrain_sdm.py
@@ -18,7 +18,7 @@ from accelerate import Accelerator
 import wandb
 
 from models.sdm_ssm import SDM_SSM, SDM_MambaBlock
-from data.wikitext103 import get_wiktext103_dataloader
+from data.wikitext103 import get_wikitext103_dataloader
 from utils.logger import setup_logger, setup_wandb, log_model_info, log_training_info
 from utils.profiling import count_parameters
 
@@ -310,7 +310,7 @@ def main():
     num_workers = int(data_config.get('num_workers', 4))
     
     # Create data loaders
-    train_dataloader = get_wiktext103_dataloader(
+    train_dataloader = get_wikitext103_dataloader(
         tokenizer_name="gpt2",
         batch_size=micro_batch_size,
         max_length=max_length,
@@ -318,7 +318,7 @@ def main():
         num_workers=num_workers
     )
     
-    val_dataloader = get_wiktext103_dataloader(
+    val_dataloader = get_wikitext103_dataloader(
         tokenizer_name="gpt2",
         batch_size=micro_batch_size,
         max_length=max_length,

--- a/scripts/analyze_sdm.py
+++ b/scripts/analyze_sdm.py
@@ -26,7 +26,7 @@ parent_dir = os.path.dirname(script_dir)
 sys.path.insert(0, parent_dir)
 
 from models.sdm_ssm import SDM_SSM, SDM_MambaBlock
-from data.wikitext103 import get_wiktext103_dataloader
+from data.wikitext103 import get_wikitext103_dataloader
 from utils.profiling import count_parameters
 
 

--- a/scripts/profile_memory.py
+++ b/scripts/profile_memory.py
@@ -41,7 +41,7 @@ from models.baseline_ssm import BaselineSSM
 from models.sdm_ssm import SDM_SSM
 from models.sgh_peft import SGHPEFTModel
 from utils.profiling import count_parameters
-from data.wikitext103 import get_wiktext103_dataloader
+from data.wikitext103 import get_wikitext103_dataloader
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/scripts/run_csp_analysis.py
+++ b/scripts/run_csp_analysis.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 
 # Import using absolute path to avoid conflicts
 from models.baseline_ssm import BaselineSSM
-from data.wikitext103 import get_wiktext103_dataloader
+from data.wikitext103 import get_wikitext103_dataloader
 from utils.logger import setup_logger
 
 # A list to store the captured hidden states from the forward hook
@@ -242,7 +242,7 @@ def main():
     
     # Use the WikiText-103 validation set, as specified in the proposal
     try:
-        dataloader = get_wiktext103_dataloader(
+        dataloader = get_wikitext103_dataloader(
             batch_size=16,  # Smaller batch size for memory efficiency
             max_length=512,
             split="validation",

--- a/scripts/run_validation_suite.py
+++ b/scripts/run_validation_suite.py
@@ -36,7 +36,7 @@ from models.sgh_peft import (
     MaskedLoRALayer,
     create_sgh_peft_model,
 )
-from data.wikitext103 import get_wiktext103_dataloader
+from data.wikitext103 import get_wikitext103_dataloader
 from data.glue import get_glue_dataloader
 from utils.profiling import count_parameters, measure_latency
 from transformers import AutoTokenizer
@@ -169,7 +169,7 @@ class ValidationSuite:
         
         # 2. Perplexity Calculation on WikiText-103
         try:
-            val_dataloader = get_wiktext103_dataloader(
+            val_dataloader = get_wikitext103_dataloader(
                 tokenizer=self.tokenizer,
                 batch_size=8,
                 max_length=1024,

--- a/scripts/setup_datasets.sh
+++ b/scripts/setup_datasets.sh
@@ -25,9 +25,9 @@ sys.path.append('${PROJECT_ROOT}')
 
 try:
     if '${dataset_name}' == 'wikitext103':
-        from data.wikitext103 import get_wiktext103_dataloader
+        from data.wikitext103 import get_wikitext103_dataloader
         # Test loading a small sample
-        dataloader = get_wiktext103_dataloader(
+        dataloader = get_wikitext103_dataloader(
             split='train',
             batch_size=2,
             max_length=128,

--- a/tests/test_full_experiment.sh
+++ b/tests/test_full_experiment.sh
@@ -303,7 +303,7 @@ project_imports = [
     ('models.baseline_ssm', 'BaselineSSM'),
     ('models.sdm_ssm', 'SDM_SSM'),
     ('utils.logger', 'setup_logger'),
-    ('data.wikitext103', 'get_wiktext103_dataloader'),
+    ('data.wikitext103', 'get_wikitext103_dataloader'),
 ]
 
 project_failed = []


### PR DESCRIPTION
## Summary
- rename `get_wiktext103_dataloader` to `get_wikitext103_dataloader`
- update all imports and call sites
- adjust unit test import check

## Testing
- `python tests/run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684ea91409a08333a3a195880801cee0