### PR TITLE
Update Phase A hyperparameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ model:
   d_conv: 4             # Convolution kernel size
 
 training:
-  batch_size: 32        # Training batch size
-  learning_rate: 1e-4   # Learning rate
+  batch_size: 128       # Training batch size
+  learning_rate: 2e-4   # Learning rate
   max_steps: 100000     # Maximum training steps
 ```
 

--- a/configs/pretrain_base.yaml
+++ b/configs/pretrain_base.yaml
@@ -9,11 +9,11 @@ model:
 
 training:
   pretrain:
-    batch_size: 32
+    batch_size: 128
     micro_batch_size: 8
-    learning_rate: 1e-4
+    learning_rate: 2e-4
     weight_decay: 0.1
-    warmup_steps: 1000
+    warmup_steps_ratio: 0.1
     max_epochs: 20
     max_grad_norm: 1.0
 


### PR DESCRIPTION
## Summary
- adjust Phase A training hyperparameters in `configs/pretrain_base.yaml`
- update README snippet to show new pre-training settings

## Testing
- `python tests/run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684ea91e0e4883338eab60ded0e9a7af